### PR TITLE
Fixes getting MissingPluginException(No implementation found for method) during background notifications in Android

### DIFF
--- a/core/android/src/main/kotlin/com/moengage/flutter/EventEmitterImpl.kt
+++ b/core/android/src/main/kotlin/com/moengage/flutter/EventEmitterImpl.kt
@@ -15,7 +15,7 @@ import java.util.*
  * @author Arshiya Khanum
  * Date: 2020/10/21
  */
-class EventEmitterImpl : EventEmitter {
+class EventEmitterImpl(private val onEvent: (methodName: String, payload: String) -> Unit) : EventEmitter {
 
     private val tag: String = "${MODULE_TAG}EventEmitterImpl"
 
@@ -74,7 +74,7 @@ class EventEmitterImpl : EventEmitter {
     private fun emit(methodName: String, payload: JSONObject) {
         try {
             Logger.v("$tag emit() : methodName: $methodName")
-            MoEngageFlutterPlugin.sendCallback(methodName, payload.toString())
+            onEvent(methodName, payload.toString())
         } catch (e: Exception) {
             Logger.e("$tag emit() : ", e)
         }


### PR DESCRIPTION
Error: `flutter/lib/ui/ui_dart_state.cc(199)] Unhandled Exception: MissingPluginException(No implementation found for method initialise on channel com.moengage/core)
E/flutter ( 2546): #0 MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:156:7)`

Support ticket number: (63979)

Solved issue description:  Fixes getting MissingPluginException(No implementation found for method ...) during background notifications (terminated app) in Android by modifing the way communication with Flutter MethodChannel implmented in Android.

Steps to reproduce the issue:
1- Add [firebase_messaging ](https://pub.dev/packages/firebase_messaging) to your project
2- Implement [FirebaseMessaging.onBackgroundMessage](https://firebase.flutter.dev/docs/messaging/usage#background-messages) in Flutter
3- Kill the app and send a moengage or firebase notification in the background
4- MissingPluginException(No implementation found for method) is thrown for any moengage method call
