### PR TITLE
Update MoEngage iOS SDK to 10.02 for EAA compliance

### DIFF
--- a/packages/moengage_flutter/moengage_flutter/pubspec.yaml
+++ b/packages/moengage_flutter/moengage_flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   flutter:
     sdk: flutter
   moengage_flutter_android: 3.3.1
-  moengage_flutter_ios: 3.3.0
+  moengage_flutter_ios: 3.3.1
   moengage_flutter_platform_interface: 3.2.0
   moengage_flutter_web: 4.1.0
 

--- a/packages/moengage_flutter/moengage_flutter_ios/ios/moengage_flutter_ios.podspec
+++ b/packages/moengage_flutter/moengage_flutter_ios/ios/moengage_flutter_ios.podspec
@@ -19,7 +19,8 @@ Pod::Spec.new do |s|
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'MoEngagePluginBase', '5.3.0'
+  s.dependency 'MoEngagePluginBase', '~> 6.1'
+  s.dependency 'MoEngage-iOS-SDK', '~> 10.02'
   s.swift_version = '5.0'
   s.prepare_command = <<-CMD
       echo // Generated file, do not edit > Classes/MoEngageFlutterPluginInfo.swift

--- a/packages/moengage_flutter/moengage_flutter_ios/pubspec.yaml
+++ b/packages/moengage_flutter/moengage_flutter_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: moengage_flutter_ios
 description: iOS implementation of the moengage_flutter plugin
-version: 3.3.0
+version: 3.3.1
 homepage: https://www.moengage.com
 
 environment:


### PR DESCRIPTION
### Jira Ticket

### Description
🚀 What Changed
	•	Upgrades MoEngagePluginBase to ~> 6.1
	•	Bumps MoEngage‑iOS‑SDK to ~> 10.02 (resulting in version 10.02.2)
	•	Applies these changes to packages/moengage_flutter/moengage_flutter_ios/ios/moengage_flutter_ios.podspec

⸻

💬 Why These Changes
	•	The client email mandates upgrading iOS MoEngage SDK to 10.01.0 or higher
	•	The latest 10.02.2 version is EAA-compliant and ensures the Flutter plugin works seamlessly with minimal version 
