### PR TITLE
Removing the redundant dependency inclusion for `moe-android-sdk`

### DIFF
--- a/packages/moengage_personalize/moengage_personalize/CHANGELOG.md
+++ b/packages/moengage_personalize/moengage_personalize/CHANGELOG.md
@@ -1,5 +1,12 @@
 # MoEngage Personalize Plugin
 
+# Release Date
+
+## Release Version
+
+- Android
+  - [patch] Removing the redundant dependency inclusion for `moe-android-sdk`
+
 # 07-05-2026
 
 ## 1.0.0

--- a/packages/moengage_personalize/moengage_personalize_android/CHANGELOG.md
+++ b/packages/moengage_personalize/moengage_personalize_android/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MoEngage Personalize Android Plugin
 
+# Release Date
+
+## Release Version
+
+- [patch] Removing the redundant dependency inclusion for `moe-android-sdk`
+
 # 07-05-2026
 
 ## 1.0.0

--- a/packages/moengage_personalize/moengage_personalize_android/android/build.gradle
+++ b/packages/moengage_personalize/moengage_personalize_android/android/build.gradle
@@ -52,9 +52,6 @@ dependencies {
     compileOnly("com.moengage:plugin-base")
 
     implementation(platform("com.moengage:android-bom:$moengageNativeBomVersion"))
-    compileOnly(platform("com.moengage:android-bom:$moengageNativeBomVersion")) {
-        exclude group: 'com.moengage', module: 'core'
-    }
     compileOnly("com.moengage:moe-android-sdk")
     api("com.moengage:personalization-core")
 }


### PR DESCRIPTION
### Jira Ticket

### Description
Removing the redundant dependency inclusion for `moe-android-sdk`
