### PR TITLE
MOEN-45889: Fix update-dependency workflow release type detection

### DIFF
--- a/.github/scripts/update-bom.main.kts
+++ b/.github/scripts/update-bom.main.kts
@@ -144,6 +144,18 @@ fun findChangedArtifacts(bomArtifact: String, oldVersion: String, newVersion: St
     return changed
 }
 
+// ── Semver Diff ──────────────────────────────────────────────────────────────
+
+fun determineReleaseType(oldVersion: String, newVersion: String): String {
+    val oldParts = oldVersion.split(".").map { it.toIntOrNull() ?: 0 }
+    val newParts = newVersion.split(".").map { it.toIntOrNull() ?: 0 }
+    return when {
+        newParts.getOrElse(0) { 0 } != oldParts.getOrElse(0) { 0 } -> "major"
+        newParts.getOrElse(1) { 0 } != oldParts.getOrElse(1) { 0 } -> "minor"
+        else -> "patch"
+    }
+}
+
 // ── Gradle File Update ─────────────────────────────────────────────────────────
 
 fun readCurrentVersion(file: File, versionKey: String): String? {


### PR DESCRIPTION
## Summary
- `update-bom.main.kts` and `update-ios-deps.main.kts` always tagged the changelog bom/pod-version bump as `[minor]`, regardless of the actual semver change.
- Added a `determineReleaseType(oldVersion, newVersion)` helper to both scripts that compares major/minor components of the old vs. new version and tags the entry `[major]`, `[minor]`, or `[patch]` accordingly.
- Updated the existing-entry regexes so re-runs correctly detect and replace entries tagged with any of the three release types, not just `[minor]`.

## Test plan
- [ ] Trigger the "Update Dependency" workflow with a patch-level android-bom bump and confirm changelog entries are tagged `[patch]`.
- [ ] Trigger with a minor-level bump and confirm `[minor]`.
- [ ] Trigger with a major-level bump and confirm `[major]`.
- [ ] Confirm `pre-release.main.kts` picks up the correct release type from the tagged entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)