### PR TITLE
MOEN-45889: Upgrade AGP to 9.1.1 and Kotlin to 2.3.20 to match native SDK

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id "com.android.application"
-  id "kotlin-android"
   id "dev.flutter.flutter-gradle-plugin"
   id "com.google.gms.google-services"
   id "com.huawei.agconnect"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:8.13.2'
+    classpath 'com.android.tools.build:gradle:9.1.1'
   }
 }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,4 +1,2 @@
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536M
-android.defaults.buildfeatures.buildconfig=true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 10 15:19:57 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -29,8 +29,9 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.13.2" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.23" apply false
+    // Kotlin support is built into AGP as of 9.0, so org.jetbrains.kotlin.android
+    // is no longer applied/declared here.
+    id "com.android.application" version "9.1.1" apply false
     id "com.google.gms.google-services" version "4.4.2" apply false
     id "com.huawei.agconnect" version "1.9.1.302" apply false
 }

--- a/packages/moengage_cards/moengage_cards/CHANGELOG.md
+++ b/packages/moengage_cards/moengage_cards/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Release Version
 
 - [major] Updated minimum supported Dart SDK to `3.6.0` and minimum Flutter SDK to `3.27.0`
+- Android
+  - [major] Upgraded Android Gradle Plugin (AGP) to `9.1.1` and Kotlin to `2.3.20`.
 
 # 17-06-2026
 

--- a/packages/moengage_cards/moengage_cards_android/CHANGELOG.md
+++ b/packages/moengage_cards/moengage_cards_android/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Release Version
 
 - [major] Updated minimum supported Dart SDK to `3.6.0` and minimum Flutter SDK to `3.27.0`
+- [major] Upgraded Android Gradle Plugin (AGP) to `9.1.1` and Kotlin to `2.3.20`.
 
 # 17-06-2026
 

--- a/packages/moengage_cards/moengage_cards_android/android/build.gradle
+++ b/packages/moengage_cards/moengage_cards_android/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.moengage.flutter_cards'
 version '1.0'
 
 buildscript {
-    ext.kotlin_version = '1.9.23'
+    ext.kotlin_version = '2.3.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.2'
+        classpath 'com.android.tools.build:gradle:9.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.moengage.android.hybrid.module.config.plugin:com.moengage.android.hybrid.module.config.plugin.gradle.plugin:0.0.5"
         // classpath "org.jlleitschuh.gradle:ktlint-gradle:12.1.1"

--- a/packages/moengage_cards/moengage_cards_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/moengage_cards/moengage_cards_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/packages/moengage_flutter/moengage_flutter/CHANGELOG.md
+++ b/packages/moengage_flutter/moengage_flutter/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Release Version
 
 - [major] Updated minimum supported Dart SDK to `3.6.0` and minimum Flutter SDK to `3.27.0`
+- Android
+  - [major] Upgraded Android Gradle Plugin (AGP) to `9.1.1` and Kotlin to `2.3.20`.
 
 # 17-06-2026
 

--- a/packages/moengage_flutter/moengage_flutter_android/CHANGELOG.md
+++ b/packages/moengage_flutter/moengage_flutter_android/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Release Version
 
 - [major] Updated minimum supported Dart SDK to `3.6.0` and minimum Flutter SDK to `3.27.0`
+- [major] Upgraded Android Gradle Plugin (AGP) to `9.1.1` and Kotlin to `2.3.20`.
 
 # 17-06-2026
 

--- a/packages/moengage_flutter/moengage_flutter_android/android/build.gradle
+++ b/packages/moengage_flutter/moengage_flutter_android/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.moengage.flutter'
 version '1.0'
 
 buildscript {
-    ext.kotlin_version = '1.9.23'
+    ext.kotlin_version = '2.3.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:8.13.2"
+        classpath "com.android.tools.build:gradle:9.1.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.moengage.android.hybrid.module.config.plugin:com.moengage.android.hybrid.module.config.plugin.gradle.plugin:0.0.5"
     }

--- a/packages/moengage_flutter/moengage_flutter_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/moengage_flutter/moengage_flutter_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 10 12:53:35 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/moengage_geofence/moengage_geofence/CHANGELOG.md
+++ b/packages/moengage_geofence/moengage_geofence/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Release Version
 
 - [major] Updated minimum supported Dart SDK to `3.6.0` and minimum Flutter SDK to `3.27.0`
+- Android
+  - [major] Upgraded Android Gradle Plugin (AGP) to `9.1.1` and Kotlin to `2.3.20`.
 
 # 17-06-2026
 

--- a/packages/moengage_geofence/moengage_geofence_android/CHANGELOG.md
+++ b/packages/moengage_geofence/moengage_geofence_android/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Release Version
 
 - [major] Updated minimum supported Dart SDK to `3.6.0` and minimum Flutter SDK to `3.27.0`
+- [major] Upgraded Android Gradle Plugin (AGP) to `9.1.1` and Kotlin to `2.3.20`.
 
 # 17-06-2026
 

--- a/packages/moengage_geofence/moengage_geofence_android/android/build.gradle
+++ b/packages/moengage_geofence/moengage_geofence_android/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.moengage.moengage_geofence'
 version '1.0'
 
 buildscript {
-    ext.kotlin_version = '1.9.23'
+    ext.kotlin_version = '2.3.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.2'
+        classpath 'com.android.tools.build:gradle:9.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.moengage.android.hybrid.module.config.plugin:com.moengage.android.hybrid.module.config.plugin.gradle.plugin:0.0.5"
         // classpath "org.jlleitschuh.gradle:ktlint-gradle:12.1.1"

--- a/packages/moengage_geofence/moengage_geofence_android/android/gradle.properties
+++ b/packages/moengage_geofence/moengage_geofence_android/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/moengage_geofence/moengage_geofence_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/moengage_geofence/moengage_geofence_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/packages/moengage_inbox/moengage_inbox/CHANGELOG.md
+++ b/packages/moengage_inbox/moengage_inbox/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Release Version
 
 - [major] Updated minimum supported Dart SDK to `3.6.0` and minimum Flutter SDK to `3.27.0`
+- Android
+  - [major] Upgraded Android Gradle Plugin (AGP) to `9.1.1` and Kotlin to `2.3.20`.
 
 # 17-06-2026
 

--- a/packages/moengage_inbox/moengage_inbox_android/CHANGELOG.md
+++ b/packages/moengage_inbox/moengage_inbox_android/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Release Version
 
 - [major] Updated minimum supported Dart SDK to `3.6.0` and minimum Flutter SDK to `3.27.0`
+- [major] Upgraded Android Gradle Plugin (AGP) to `9.1.1` and Kotlin to `2.3.20`.
 
 # 17-06-2026
 

--- a/packages/moengage_inbox/moengage_inbox_android/android/build.gradle
+++ b/packages/moengage_inbox/moengage_inbox_android/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.moengage.moengage_inbox'
 version '1.0'
 
 buildscript {
-    ext.kotlin_version = '1.9.23'
+    ext.kotlin_version = '2.3.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.2'
+        classpath 'com.android.tools.build:gradle:9.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.moengage.android.hybrid.module.config.plugin:com.moengage.android.hybrid.module.config.plugin.gradle.plugin:0.0.5"
         // classpath "org.jlleitschuh.gradle:ktlint-gradle:12.1.1"

--- a/packages/moengage_inbox/moengage_inbox_android/android/gradle.properties
+++ b/packages/moengage_inbox/moengage_inbox_android/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/moengage_inbox/moengage_inbox_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/moengage_inbox/moengage_inbox_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/packages/moengage_personalize/moengage_personalize/CHANGELOG.md
+++ b/packages/moengage_personalize/moengage_personalize/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Release Version
 
 - [major] Updated minimum supported Dart SDK to `3.6.0` and minimum Flutter SDK to `3.27.0`
+- Android
+  - [major] Upgraded Android Gradle Plugin (AGP) to `9.1.1` and Kotlin to `2.3.20`.
 
 # 17-06-2026
 

--- a/packages/moengage_personalize/moengage_personalize_android/CHANGELOG.md
+++ b/packages/moengage_personalize/moengage_personalize_android/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Release Version
 
 - [major] Updated minimum supported Dart SDK to `3.6.0` and minimum Flutter SDK to `3.27.0`
+- [major] Upgraded Android Gradle Plugin (AGP) to `9.1.1` and Kotlin to `2.3.20`.
 
 # 17-06-2026
 

--- a/packages/moengage_personalize/moengage_personalize_android/android/build.gradle
+++ b/packages/moengage_personalize/moengage_personalize_android/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.moengage.flutter_personalize'
 version '1.0'
 
 buildscript {
-    ext.kotlin_version = '1.9.23'
+    ext.kotlin_version = '2.3.20'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.2'
+        classpath 'com.android.tools.build:gradle:9.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.moengage.android.hybrid.module.config.plugin:com.moengage.android.hybrid.module.config.plugin.gradle.plugin:0.0.5"
         // classpath "org.jlleitschuh.gradle:ktlint-gradle:12.1.1"

--- a/packages/moengage_personalize/moengage_personalize_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/moengage_personalize/moengage_personalize_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip


### PR DESCRIPTION
## Summary
- Bump AGP (`com.android.tools.build:gradle`) to `9.1.1` and the Kotlin Gradle plugin to `2.3.20` — matching the versions used by the native Android SDK (`kotlinVersion = 2.3.20`, `agpVersion = 9.1.1`) — across the example app and all Flutter package Android modules (`moengage_flutter`, `moengage_cards`, `moengage_inbox`, `moengage_geofence`, `moengage_personalize`).
- Bump each module's Gradle wrapper to `9.3.1`, the minimum Gradle version AGP 9.1.1 requires (confirmed empirically — AGP itself rejects anything lower).
- Drop `gradle.properties` flags AGP 9 removed: `android.defaults.buildfeatures.buildconfig` and `android.enableJetifier` (both deprecated/removed, and the equivalent behavior is already set explicitly elsewhere).
- AGP 9 bundles Kotlin support directly, so the example app no longer applies `kotlin-android` explicitly (AGP throws if you do). The plugin library modules still apply Kotlin via the third-party `com.moengage.android.hybrid.module.config.plugin`, which will need a follow-up if it explicitly applies the now-redundant Kotlin plugin too.

## ⚠️ Known issue — Android build currently fails on every stable Flutter release
While verifying this change I hit a hard blocker unrelated to this repo's config:

`flutter build apk` fails with:
```
Failed to apply plugin 'dev.flutter.flutter-gradle-plugin'.
> java.lang.NullPointerException
Caused by: java.lang.NullPointerException
  at com.flutter.gradle.FlutterPluginUtils.getAndroidExtension$gradle(FlutterPluginUtils.kt:399)
```

AGP 9 removed the legacy `com.android.build.gradle.BaseExtension` class. Flutter's stable Gradle plugin still does `project.extensions.findByType(BaseExtension::class.java)!!`, which now returns `null`. I verified this reproduces on both Flutter `3.27.0` (this repo's documented minimum) and `3.35.5` (latest stable). Diffing against Flutter's `master` branch shows this was fixed there by refactoring to `ApplicationExtension`/`AgpCommonExtensionWrapper` — but that fix has not shipped in any stable release yet.

**Net effect:** this version bump is correct and matches the native SDK's build tooling, but the Android app cannot be built end-to-end with any currently released Flutter SDK until Flutter ships stable support for AGP 9. Shipping as requested; revisit once upstream support lands.

## Test plan
- [x] Confirmed AGP/Kotlin/Gradle version consistency across all 6 Android modules.
- [x] Confirmed Gradle 9.3.1 is the actual minimum AGP 9.1.1 will accept (verified via direct Gradle error, not just docs).
- [ ] `flutter build apk` — blocked by the Flutter stable-release gap above; re-verify once Flutter ships AGP 9 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)