### PR TITLE
MOEN-46850: Fix ANR in Inbox fetchMessages API

### DIFF
--- a/packages/moengage_inbox/moengage_inbox/CHANGELOG.md
+++ b/packages/moengage_inbox/moengage_inbox/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Android
   - [minor] `android-bom` version updated to `2.3.0`.
+  - BugFix:
+    - [patch] ANR in `fetchMessages` API caused by serialising the inbox message payload on the Main Thread.
 - iOS
     - [minor] Updated `MoEngage-iOS-SDK` to `10.14.0`.
 

--- a/packages/moengage_inbox/moengage_inbox_android/CHANGELOG.md
+++ b/packages/moengage_inbox/moengage_inbox_android/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Release Version
 
 - [minor] `android-bom` version updated to `2.3.0`.
+- BugFix:
+  - [patch] ANR in `fetchMessages` API caused by serialising the inbox message payload on the Main Thread.
 
 # 17-06-2026
 

--- a/packages/moengage_inbox/moengage_inbox_android/android/src/main/kotlin/com/moengage/flutter/inbox/MoEngageInboxPlugin.kt
+++ b/packages/moengage_inbox/moengage_inbox_android/android/src/main/kotlin/com/moengage/flutter/inbox/MoEngageInboxPlugin.kt
@@ -111,20 +111,18 @@ class MoEngageInboxPlugin : FlutterPlugin, MethodCallHandler {
             if (call.arguments == null) return
             val payload: String = call.arguments.toString()
             executorService.submit {
-                val inboxData: InboxData? = inboxHelper.fetchAllMessages(context, payload)
-                if (inboxData == null) {
-                    result.error(ERROR_CODE_INBOX, "Inbox Message cannot be fetched", null)
-                    return@submit
-                }
-                val serialisedMessages = inboxDataToJson(inboxData)
-                mainThread.post {
-                    try {
-                        Logger.print { "$tag fetchMessages() : serialisedMessages: $serialisedMessages" }
-                        result.success(serialisedMessages.toString())
-                    } catch (t: Throwable) {
+                try {
+                    val inboxData: InboxData? = inboxHelper.fetchAllMessages(context, payload)
+                    if (inboxData == null) {
                         result.error(ERROR_CODE_INBOX, "Inbox Message cannot be fetched", null)
-                        Logger.print(LogLevel.ERROR, t) { "$tag fetchMessages() : " }
+                        return@submit
                     }
+                    val serialisedMessages = inboxDataToJson(inboxData).toString()
+                    Logger.print { "$tag fetchMessages() : serialisedMessages: $serialisedMessages" }
+                    mainThread.post { result.success(serialisedMessages) }
+                } catch (t: Throwable) {
+                    result.error(ERROR_CODE_INBOX, "Inbox Message cannot be fetched", null)
+                    Logger.print(LogLevel.ERROR, t) { "$tag fetchMessages() : " }
                 }
             }
         } catch (t: Throwable) {


### PR DESCRIPTION
### Jira Ticket
https://moengagetrial.atlassian.net/browse/MOEN-46850

## Description

`MoEngageInboxPlugin.fetchMessages` serialised the inbox payload on the main thread. `inboxDataToJson()` returns a `JSONObject` holding every inbox message, and both the verbose log and `result.success()` invoked `toString()` on it from inside `mainThread.post`. Walking that tree costs time proportional to inbox size, so users with large inboxes on low/mid-tier devices tipped into an ANR.

## Changes

- Serialise on the worker thread and post only the finished `String` to the platform thread.
- Move the log off the main thread so it no longer re-serialises the payload when verbose logging is enabled.
- Wrap the worker block in a `try/catch`, so a serialisation failure (e.g. OOM on a very large inbox) replies with an error instead of leaving the awaited Dart future hanging forever.


## Notes for reviewers

- Replying off the platform thread is intentional and safe: `FlutterJNI.invokePlatformMessageResponseCallback` guards with a `shellHolderLock` read lock and deliberately omits the `ensureRunningOnMainThread()` assertion that ~30 sibling methods carry.
- `result.success` also encodes the reply envelope (a UTF-8 copy of the whole payload) on the calling thread, so the remaining `mainThread.post` leaves one O(payload) copy on main. Much cheaper than the JSON tree-walk that caused the ANR, but it could be dropped in a follow-up.
- **`moengage_cards` has the same defect class and is not fixed here**: `PlatformMethodCallHandler.fetchCards` builds *and* stringifies the whole card list on the main thread. Note `cardAvailableListener` is already invoked on main by cards-core (`CardController.kt:187`), so fixing it needs a deliberate hop back to a worker plus its own version bump — worth a separate ticket.