### PR TITLE
MOEN-46898: Update android-bom to 2.3.1

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -22,7 +22,7 @@ if (flutterVersionName == null) {
 }
 
 ext {
-  moengageNativeBomVersion = "2.3.0"
+  moengageNativeBomVersion = "2.3.1"
 }
 
 apply plugin: 'com.android.application'

--- a/packages/moengage_cards/moengage_cards/CHANGELOG.md
+++ b/packages/moengage_cards/moengage_cards/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Release Version
 
 - Android
-  - [minor] `android-bom` version updated to `2.3.0`.
+  - [minor] `android-bom` version updated to `2.3.1`.
 - iOS
     - [minor] Updated `MoEngage-iOS-SDK` to `10.14.0`.
 

--- a/packages/moengage_cards/moengage_cards_android/CHANGELOG.md
+++ b/packages/moengage_cards/moengage_cards_android/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Release Version
 
-- [minor] `android-bom` version updated to `2.3.0`.
+- [minor] `android-bom` version updated to `2.3.1`.
 
 # 17-06-2026
 

--- a/packages/moengage_cards/moengage_cards_android/android/build.gradle
+++ b/packages/moengage_cards/moengage_cards_android/android/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 }
 
 ext {
-    moengageNativeBomVersion = "2.3.0"
+    moengageNativeBomVersion = "2.3.1"
     moengagePluginBaseBomVersion = "3.1.0"
 }
 

--- a/packages/moengage_flutter/moengage_flutter/CHANGELOG.md
+++ b/packages/moengage_flutter/moengage_flutter/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Release Version
 
 - Android
-  - [minor] `android-bom` version updated to `2.3.0`.
+  - [minor] `android-bom` version updated to `2.3.1`.
 - iOS
     - [minor] Updated `MoEngage-iOS-SDK` to `10.14.0`.
 

--- a/packages/moengage_flutter/moengage_flutter_android/CHANGELOG.md
+++ b/packages/moengage_flutter/moengage_flutter_android/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Release Version
 
-- [minor] `android-bom` version updated to `2.3.0`.
+- [minor] `android-bom` version updated to `2.3.1`.
 
 # 17-06-2026
 

--- a/packages/moengage_flutter/moengage_flutter_android/android/build.gradle
+++ b/packages/moengage_flutter/moengage_flutter_android/android/build.gradle
@@ -25,7 +25,7 @@ rootProject.allprojects {
 
 
 ext {
-    moengageNativeBomVersion = "2.3.0"
+    moengageNativeBomVersion = "2.3.1"
     moengagePluginBaseBomVersion = "3.1.0"
 }
 

--- a/packages/moengage_geofence/moengage_geofence/CHANGELOG.md
+++ b/packages/moengage_geofence/moengage_geofence/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Release Version
 
 - Android
-  - [minor] `android-bom` version updated to `2.3.0`.
+  - [minor] `android-bom` version updated to `2.3.1`.
 - iOS
     - [minor] Updated `MoEngage-iOS-SDK` to `10.14.0`.
 

--- a/packages/moengage_geofence/moengage_geofence_android/CHANGELOG.md
+++ b/packages/moengage_geofence/moengage_geofence_android/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Release Version
 
-- [minor] `android-bom` version updated to `2.3.0`.
+- [minor] `android-bom` version updated to `2.3.1`.
 
 # 17-06-2026
 

--- a/packages/moengage_geofence/moengage_geofence_android/android/build.gradle
+++ b/packages/moengage_geofence/moengage_geofence_android/android/build.gradle
@@ -25,7 +25,7 @@ rootProject.allprojects {
 }
 
 ext {
-    moengageNativeBomVersion = "2.3.0"
+    moengageNativeBomVersion = "2.3.1"
     moengagePluginBaseBomVersion = "3.1.0"
 }
 

--- a/packages/moengage_inbox/moengage_inbox/CHANGELOG.md
+++ b/packages/moengage_inbox/moengage_inbox/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Release Version
 
 - Android
-  - [minor] `android-bom` version updated to `2.3.0`.
+  - [minor] `android-bom` version updated to `2.3.1`.
   - BugFix:
     - [patch] ANR in `fetchMessages` API caused by serialising the inbox message payload on the Main Thread.
 - iOS

--- a/packages/moengage_inbox/moengage_inbox_android/CHANGELOG.md
+++ b/packages/moengage_inbox/moengage_inbox_android/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Release Version
 
-- [minor] `android-bom` version updated to `2.3.0`.
+- [minor] `android-bom` version updated to `2.3.1`.
 - BugFix:
   - [patch] ANR in `fetchMessages` API caused by serialising the inbox message payload on the Main Thread.
 

--- a/packages/moengage_inbox/moengage_inbox_android/android/build.gradle
+++ b/packages/moengage_inbox/moengage_inbox_android/android/build.gradle
@@ -25,7 +25,7 @@ rootProject.allprojects {
 }
 
 ext {
-    moengageNativeBomVersion = "2.3.0"
+    moengageNativeBomVersion = "2.3.1"
     moengagePluginBaseBomVersion = "3.1.0"
 }
 

--- a/packages/moengage_personalize/moengage_personalize/CHANGELOG.md
+++ b/packages/moengage_personalize/moengage_personalize/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Release Version
 
 - Android
-  - [minor] `android-bom` version updated to `2.3.0`.
+  - [minor] `android-bom` version updated to `2.3.1`.
 - iOS
     - [minor] Updated `MoEngage-iOS-SDK` to `10.14.0`.
 

--- a/packages/moengage_personalize/moengage_personalize_android/CHANGELOG.md
+++ b/packages/moengage_personalize/moengage_personalize_android/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Release Version
 
-- [minor] `android-bom` version updated to `2.3.0`.
+- [minor] `android-bom` version updated to `2.3.1`.
 
 # 17-06-2026
 

--- a/packages/moengage_personalize/moengage_personalize_android/android/build.gradle
+++ b/packages/moengage_personalize/moengage_personalize_android/android/build.gradle
@@ -25,7 +25,7 @@ rootProject.allprojects {
 }
 
 ext {
-    moengageNativeBomVersion = "2.3.0"
+    moengageNativeBomVersion = "2.3.1"
     moengagePluginBaseBomVersion = "3.1.0"
 }
 


### PR DESCRIPTION
## Summary

Bumps the MoEngage Android native BOM (`com.moengage:android-bom`) from `2.3.0` to `2.3.1`.

## Changes

**`build.gradle` (6 files)**
- `moengageNativeBomVersion` updated to `2.3.1` in all five `*_android` plugin modules: `moengage_flutter_android`, `moengage_cards_android`, `moengage_geofence_android`, `moengage_inbox_android`, `moengage_personalize_android`
- Same bump in `example/android/app/build.gradle`

**`CHANGELOG.md` (10 files)**
- Each package already carried an unreleased `- [minor] \`android-bom\` version updated to \`2.3.0\`.` entry under `# Release Date` / `## Release Version`; those lines were bumped in place instead of adding duplicates
- 5 Android package changelogs (top-level bullet) and 5 public package changelogs (nested under `- Android`)
- Formatting matches what `.github/scripts/update-bom.main.kts` generates, including the `[minor]` tag read by the pre-release script

🤖 Generated with [Claude Code](https://claude.com/claude-code)