### PR TITLE
MOEN-47054: Fix background push crash and add self handled in-app logs in sample app

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -81,6 +81,9 @@
         <service
             android:name="io.flutter.plugins.firebase.messaging.FlutterFirebaseMessagingService"
             tools:node="remove" />
+        <receiver
+            android:name="io.flutter.plugins.firebase.messaging.FlutterFirebaseMessagingReceiver"
+            tools:node="remove" />
         <activity
             android:name="com.moengage.pushbase.activities.PushTracker"
             android:launchMode="singleInstance"

--- a/example/lib/inapp.dart
+++ b/example/lib/inapp.dart
@@ -60,15 +60,23 @@ class _InAppHomeScreenState extends State<InAppHomeScreen> {
     final SelfHandledActions? action = await asyncSelfHandledDialog(context);
     switch (action) {
       case SelfHandledActions.Shown:
+        debugPrint(
+            '$tag Main : handleAction() : Self Handled InApp Shown callback invoked. Payload $message');
         _moengagePlugin.selfHandledShown(message);
         break;
       case SelfHandledActions.Clicked:
+        debugPrint(
+            '$tag Main : handleAction() : Self Handled InApp Clicked callback invoked. Payload $message');
         _moengagePlugin.selfHandledClicked(message);
         break;
       case SelfHandledActions.Dismissed:
+        debugPrint(
+            '$tag Main : handleAction() : Self Handled InApp Dismissed callback invoked. Payload $message');
         _moengagePlugin.selfHandledDismissed(message);
         break;
       default:
+        debugPrint(
+            '$tag Main : handleAction() : No action selected for Self Handled InApp. Payload $message');
         break;
     }
   }
@@ -153,6 +161,12 @@ class _InAppHomeScreenState extends State<InAppHomeScreen> {
             title: const Text('Get Self handled InApps'),
             onTap: () {
               _moengagePlugin.getSelfHandledInApps().then((campaignsData) {
+                debugPrint(
+                    '$tag Main : getSelfHandledInApps() : Received ${campaignsData.campaigns.length} self handled campaign(s).');
+                for (var i = 0; i < campaignsData.campaigns.length; i++) {
+                  debugPrint(
+                      '$tag Main : getSelfHandledInApps() : Campaign[$i] = ${campaignsData.campaigns[i].campaign}');
+                }
                 _showBottomSheet(campaignsData, context);
               }).catchError((e) {
                 debugPrint('Error in getting self handled inapps $e');


### PR DESCRIPTION
## Summary
Fixes [MOEN-47054](https://moengagetrial.atlassian.net/browse/MOEN-47054) — Flutter sample app crashed with
`IllegalArgumentException: Tried to schedule job for non-existent component: ...FlutterFirebaseMessagingBackgroundService`
when a push notification was received while the app was backgrounded.

## Root cause
The sample app manifest already excludes `firebase_messaging`'s `FlutterFirebaseMessagingService` and
`FlutterFirebaseMessagingBackgroundService` (`tools:node="remove"`) so that MoEngage's own
`MoEFireBaseMessagingService` is the sole handler of `com.google.firebase.MESSAGING_EVENT`. However,
`FlutterFirebaseMessagingReceiver` (the plugin's `BroadcastReceiver`) was never excluded, so it kept receiving
the FCM broadcast and tried to hand off processing to the now-removed `FlutterFirebaseMessagingBackgroundService`
via `JobIntentService.enqueueWork(...)`, which throws since that component no longer exists in the merged manifest.

## Changes
- `example/android/app/src/main/AndroidManifest.xml`: exclude `FlutterFirebaseMessagingReceiver` via
  `tools:node="remove"`, alongside the existing service exclusions.
- `example/lib/inapp.dart`: add `debugPrint` logs for the self handled in-app callbacks
  (`Shown`/`Clicked`/`Dismissed` in `handleAction()`) and for the campaign list returned by
  `getSelfHandledInApps()` — neither path had any logging before, making it hard to verify self handled
  in-app behavior from sample app logs.

## Verification
Confirmed via `./gradlew :app:processDebugMainManifest` that the merged manifest no longer contains
`FlutterFirebaseMessagingService`, `FlutterFirebaseMessagingBackgroundService`, or
`FlutterFirebaseMessagingReceiver`, leaving `MoEFireBaseMessagingService` as the only `MESSAGING_EVENT` handler.

[MOEN-47054]: https://moengagetrial.atlassian.net/browse/MOEN-47054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ