### PR TITLE
MOEN-46639: Declare iOS plugin pods as static frameworks

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   collection:
   firebase_messaging: ^16.4.1
   firebase_core: ^4.11.0
+  html: 0.15.6
 
 dev_dependencies:
   flutter_test:

--- a/example_spm/pubspec.yaml
+++ b/example_spm/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   collection:
   firebase_messaging: ^16.4.1
   firebase_core: ^4.11.0
+  html: 0.15.6
 
 dev_dependencies:
   flutter_test:

--- a/packages/moengage_cards/moengage_cards_ios/CHANGELOG.md
+++ b/packages/moengage_cards/moengage_cards_ios/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Release Version
 
 - [patch] Declared the iOS plugin pod as a static framework. The MoEngage iOS SDK now links its app-only modules statically, and CocoaPods rejects a target using `use_frameworks!` whose transitive dependencies include statically linked binaries — without this, `pod install` fails for integrating apps.
+- [patch] Updated `MoEngagePluginCards` to `4.01.0`.
 
 # 01-09-2026
 

--- a/packages/moengage_cards/moengage_cards_ios/CHANGELOG.md
+++ b/packages/moengage_cards/moengage_cards_ios/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MoEngage Cards iOS Plugin
 
+# Release Date
+
+## Release Version
+
+- [patch] Declared the iOS plugin pod as a static framework. The MoEngage iOS SDK now links its app-only modules statically, and CocoaPods rejects a target using `use_frameworks!` whose transitive dependencies include statically linked binaries — without this, `pod install` fails for integrating apps.
+
 # 01-09-2026
 
 ## 6.0.0

--- a/packages/moengage_cards/moengage_cards_ios/ios/moengage_cards_ios.podspec
+++ b/packages/moengage_cards/moengage_cards_ios/ios/moengage_cards_ios.podspec
@@ -24,5 +24,6 @@ Pod::Spec.new do |s|
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+  s.static_framework = true
   s.swift_version = '5.0'
 end

--- a/packages/moengage_cards/moengage_cards_ios/ios/moengage_cards_ios.podspec
+++ b/packages/moengage_cards/moengage_cards_ios/ios/moengage_cards_ios.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, '13.0'
 
   s.dependency 'Flutter'
-  s.dependency 'MoEngagePluginCards', '4.00.0'
+  s.dependency 'MoEngagePluginCards', '4.01.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/moengage_cards/moengage_cards_ios/ios/moengage_cards_ios/Package.swift
+++ b/packages/moengage_cards/moengage_cards_ios/ios/moengage_cards_ios/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "moengage-cards-ios", targets: ["moengage_cards_ios"])
     ],
     dependencies: [
-        .package(url: "https://github.com/moengage/apple-plugin-cards.git", exact: "4.00.0"),
+        .package(url: "https://github.com/moengage/apple-plugin-cards.git", exact: "4.01.0"),
         // For development
         // .package(path: "../../../../../../../../apple-plugin-cards"),
     ],

--- a/packages/moengage_flutter/moengage_flutter_ios/CHANGELOG.md
+++ b/packages/moengage_flutter/moengage_flutter_ios/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MoEngage Flutter iOS Plugin
 
+# Release Date
+
+## Release Version
+
+- [patch] Declared the iOS plugin pod as a static framework. The MoEngage iOS SDK now links its app-only modules statically, and CocoaPods rejects a target using `use_frameworks!` whose transitive dependencies include statically linked binaries — without this, `pod install` fails for integrating apps.
+
 # 01-09-2026
 
 ## 5.0.0

--- a/packages/moengage_flutter/moengage_flutter_ios/CHANGELOG.md
+++ b/packages/moengage_flutter/moengage_flutter_ios/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Release Version
 
 - [patch] Declared the iOS plugin pod as a static framework. The MoEngage iOS SDK now links its app-only modules statically, and CocoaPods rejects a target using `use_frameworks!` whose transitive dependencies include statically linked binaries — without this, `pod install` fails for integrating apps.
+- [patch] Updated `MoEngagePluginBase` to `7.01.0`.
 
 # 01-09-2026
 

--- a/packages/moengage_flutter/moengage_flutter_ios/ios/moengage_flutter_ios.podspec
+++ b/packages/moengage_flutter/moengage_flutter_ios/ios/moengage_flutter_ios.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
   s.public_header_files = "#{root}/**/*.h"
   s.dependency 'Flutter'
   s.dependency 'MoEngagePluginBase', '7.00.0'
+  s.static_framework = true
   s.swift_version = '5.0'
 
   test_file_glob = "#{s.name}/Tests/**/*.{swift}"

--- a/packages/moengage_flutter/moengage_flutter_ios/ios/moengage_flutter_ios.podspec
+++ b/packages/moengage_flutter/moengage_flutter_ios/ios/moengage_flutter_ios.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.source_files     = "#{root}/**/*"
   s.public_header_files = "#{root}/**/*.h"
   s.dependency 'Flutter'
-  s.dependency 'MoEngagePluginBase', '7.00.0'
+  s.dependency 'MoEngagePluginBase', '7.01.0'
   s.static_framework = true
   s.swift_version = '5.0'
 

--- a/packages/moengage_flutter/moengage_flutter_ios/ios/moengage_flutter_ios/Package.swift
+++ b/packages/moengage_flutter/moengage_flutter_ios/ios/moengage_flutter_ios/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "moengage-flutter-ios", targets: ["moengage_flutter_ios"])
     ],
     dependencies: [
-        .package(url: "https://github.com/moengage/iOS-PluginBase.git", exact: "7.00.0"),
+        .package(url: "https://github.com/moengage/iOS-PluginBase.git", exact: "7.01.0"),
         // For development
         // .package(path: "../../../../../../../../iOS-PluginBase")
     ],

--- a/packages/moengage_geofence/moengage_geofence_ios/CHANGELOG.md
+++ b/packages/moengage_geofence/moengage_geofence_ios/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MoEngage Geofence iOS Plugin
 
+# Release Date
+
+## Release Version
+
+- [patch] Declared the iOS plugin pod as a static framework. The MoEngage iOS SDK now links its app-only modules statically, and CocoaPods rejects a target using `use_frameworks!` whose transitive dependencies include statically linked binaries — without this, `pod install` fails for integrating apps.
+
 # 01-09-2026
 
 ## 5.0.0

--- a/packages/moengage_geofence/moengage_geofence_ios/CHANGELOG.md
+++ b/packages/moengage_geofence/moengage_geofence_ios/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Release Version
 
 - [patch] Declared the iOS plugin pod as a static framework. The MoEngage iOS SDK now links its app-only modules statically, and CocoaPods rejects a target using `use_frameworks!` whose transitive dependencies include statically linked binaries — without this, `pod install` fails for integrating apps.
+- [patch] Updated `MoEngagePluginGeofence` to `5.01.0`.
 
 # 01-09-2026
 

--- a/packages/moengage_geofence/moengage_geofence_ios/ios/moengage_geofence_ios.podspec
+++ b/packages/moengage_geofence/moengage_geofence_ios/ios/moengage_geofence_ios.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, '13.0'
   s.static_framework = true
   s.swift_version = '5.0'
-  s.dependency 'MoEngagePluginGeofence', '5.00.0'
+  s.dependency 'MoEngagePluginGeofence', '5.01.0'
 end

--- a/packages/moengage_geofence/moengage_geofence_ios/ios/moengage_geofence_ios.podspec
+++ b/packages/moengage_geofence/moengage_geofence_ios/ios/moengage_geofence_ios.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
   s.public_header_files = "#{root}/**/*.h"
   s.dependency 'Flutter'
   s.platform = :ios, '13.0'
+  s.static_framework = true
   s.swift_version = '5.0'
   s.dependency 'MoEngagePluginGeofence', '5.00.0'
 end

--- a/packages/moengage_geofence/moengage_geofence_ios/ios/moengage_geofence_ios/Package.swift
+++ b/packages/moengage_geofence/moengage_geofence_ios/ios/moengage_geofence_ios/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "moengage-geofence-ios", targets: ["moengage_geofence_ios"])
     ],
     dependencies: [
-        .package(url: "https://github.com/moengage/apple-plugin-geofence.git", exact: "5.00.0"),
+        .package(url: "https://github.com/moengage/apple-plugin-geofence.git", exact: "5.01.0"),
         // For development
         // .package(path: "../../../../../../../../apple-plugin-geofence")
     ],

--- a/packages/moengage_inbox/moengage_inbox_ios/CHANGELOG.md
+++ b/packages/moengage_inbox/moengage_inbox_ios/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Release Version
 
 - [patch] Declared the iOS plugin pod as a static framework. The MoEngage iOS SDK now links its app-only modules statically, and CocoaPods rejects a target using `use_frameworks!` whose transitive dependencies include statically linked binaries — without this, `pod install` fails for integrating apps.
+- [patch] Updated `MoEngagePluginInbox` to `5.01.0`.
 
 # 01-09-2026
 

--- a/packages/moengage_inbox/moengage_inbox_ios/CHANGELOG.md
+++ b/packages/moengage_inbox/moengage_inbox_ios/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MoEngage Inbox iOS Plugin
 
+# Release Date
+
+## Release Version
+
+- [patch] Declared the iOS plugin pod as a static framework. The MoEngage iOS SDK now links its app-only modules statically, and CocoaPods rejects a target using `use_frameworks!` whose transitive dependencies include statically linked binaries — without this, `pod install` fails for integrating apps.
+
 # 01-09-2026
 
 ## 5.0.0

--- a/packages/moengage_inbox/moengage_inbox_ios/ios/moengage_inbox_ios.podspec
+++ b/packages/moengage_inbox/moengage_inbox_ios/ios/moengage_inbox_ios.podspec
@@ -20,7 +20,7 @@ A flutter plugin for using Notification Inbox from MoEngage iOS and Android SDKs
   s.source_files     = "#{root}/**/*"
   s.public_header_files = "#{root}/**/*.h"
   s.dependency 'Flutter'
-  s.dependency 'MoEngagePluginInbox', '5.00.0'
+  s.dependency 'MoEngagePluginInbox', '5.01.0'
   s.static_framework = true
   s.swift_version = '5.0'
 end

--- a/packages/moengage_inbox/moengage_inbox_ios/ios/moengage_inbox_ios.podspec
+++ b/packages/moengage_inbox/moengage_inbox_ios/ios/moengage_inbox_ios.podspec
@@ -21,5 +21,6 @@ A flutter plugin for using Notification Inbox from MoEngage iOS and Android SDKs
   s.public_header_files = "#{root}/**/*.h"
   s.dependency 'Flutter'
   s.dependency 'MoEngagePluginInbox', '5.00.0'
+  s.static_framework = true
   s.swift_version = '5.0'
 end

--- a/packages/moengage_inbox/moengage_inbox_ios/ios/moengage_inbox_ios/Package.swift
+++ b/packages/moengage_inbox/moengage_inbox_ios/ios/moengage_inbox_ios/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "moengage-inbox-ios", targets: ["moengage_inbox_ios"])
     ],
     dependencies: [
-        .package(url: "https://github.com/moengage/apple-plugin-inbox.git", exact: "5.00.0"),
+        .package(url: "https://github.com/moengage/apple-plugin-inbox.git", exact: "5.01.0"),
         // For development
         // .package(path: "../../../../../../../../apple-plugin-inbox")
     ],

--- a/packages/moengage_personalize/moengage_personalize_ios/CHANGELOG.md
+++ b/packages/moengage_personalize/moengage_personalize_ios/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Release Version
 
 - [patch] Declared the iOS plugin pod as a static framework. The MoEngage iOS SDK now links its app-only modules statically, and CocoaPods rejects a target using `use_frameworks!` whose transitive dependencies include statically linked binaries — without this, `pod install` fails for integrating apps.
+- [patch] Updated `MoEngagePluginPersonalize` to `2.1.0`.
 
 # 01-09-2026
 

--- a/packages/moengage_personalize/moengage_personalize_ios/CHANGELOG.md
+++ b/packages/moengage_personalize/moengage_personalize_ios/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MoEngage Personalize iOS Plugin
 
+# Release Date
+
+## Release Version
+
+- [patch] Declared the iOS plugin pod as a static framework. The MoEngage iOS SDK now links its app-only modules statically, and CocoaPods rejects a target using `use_frameworks!` whose transitive dependencies include statically linked binaries — without this, `pod install` fails for integrating apps.
+
 # 01-09-2026
 
 ## 2.0.0

--- a/packages/moengage_personalize/moengage_personalize_ios/ios/moengage_personalize_ios.podspec
+++ b/packages/moengage_personalize/moengage_personalize_ios/ios/moengage_personalize_ios.podspec
@@ -19,7 +19,7 @@ A flutter plugin for using Personalize Experience feature from MoEngage iOS SDK.
   s.source_files     = "#{root}/**/*"
   s.public_header_files = "#{root}/**/*.h"
   s.dependency 'Flutter'
-  s.dependency 'MoEngagePluginPersonalize', '2.0.0'
+  s.dependency 'MoEngagePluginPersonalize', '2.1.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/moengage_personalize/moengage_personalize_ios/ios/moengage_personalize_ios.podspec
+++ b/packages/moengage_personalize/moengage_personalize_ios/ios/moengage_personalize_ios.podspec
@@ -23,5 +23,6 @@ A flutter plugin for using Personalize Experience feature from MoEngage iOS SDK.
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+  s.static_framework = true
   s.swift_version = '5.0'
 end

--- a/packages/moengage_personalize/moengage_personalize_ios/ios/moengage_personalize_ios/Package.swift
+++ b/packages/moengage_personalize/moengage_personalize_ios/ios/moengage_personalize_ios/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "moengage-personalize-ios", targets: ["moengage_personalize_ios"])
     ],
     dependencies: [
-        .package(url: "https://github.com/moengage/apple-plugin-personalize.git", exact: "2.0.0"),
+        .package(url: "https://github.com/moengage/apple-plugin-personalize.git", exact: "2.1.0"),
         // For development
         // .package(path: "../../../../../../../../apple-plugin-personalize")
     ],


### PR DESCRIPTION
### Jira Ticket

[MOEN-46639](https://moengagetrial.atlassian.net/browse/MOEN-46639) — companion to [MoEngage-iPhone-SDK#1050](https://github.com/moengage/MoEngage-iPhone-SDK/pull/1050)

### Change

`s.static_framework = true` on the five iOS plugin podspecs. No other change.

### What broke

The iOS SDK now links its 8 app-only modules statically. CocoaPods rejects any target using `use_frameworks!` whose **transitive** dependencies include statically linked binaries — and **Flutter's Podfile applies `use_frameworks!` unconditionally** (`example/ios/Podfile:83,102,107`), so this affects every Flutter app, with no opt-out.

Reproduced with the real `moengage_cards_ios.podspec` against the SDK's static branch:

```
[!] The 'Pods-FlutterRepro' target has transitive dependencies that include statically
    linked binaries: (MoEngagePluginCards, MoEngagePluginBase, MoEngageCards,
    MoEngageSDK, MoEngageInApps, and MoEngageTriggerEvaluator)
pod install → exit 1
```

`pod install` fails outright — no `.xcworkspace` is produced, so the client never reaches a build.

### What fixes it

| | `pod install` |
|---|---|
| without `static_framework` | **exit 1** |
| with it | **exit 0** |

The requirement propagates up **every** layer of the chain — verified with a three-tier test. Making `MoEngagePluginCards` static (in `apple-plugin-cards`) is not sufficient on its own; the Flutter plugin sitting above it must be static too. That's why this change is needed here as well as in the plugin repos.

### How it was tested

Real podspec, real plugin chain, pointed at the SDK's static branch, with only the `Flutter` engine pod stubbed (dynamic, as `podhelper` provides it) and the exact version pin relaxed so the local plugin could resolve. Both test-only edits reverted.

**Not verified:** the app doesn't compile in that harness, because the stub has no `FlutterPlugin` / `FlutterMethodCall` types. `pod install` failing is the client-facing breakage — clients never reach a build — but confirming compilation needs the real Flutter toolchain.

### Client impact

- **Without this change:** every Flutter app using the MoEngage plugin fails at `pod install` once the SDK release lands.
- **With it:** no change required on the client side. The alternative — asking each client to add `use_frameworks! :linkage => :static` to their Podfile — also works, but puts the burden on them.

### Precedent

Braze ships static xcframeworks and sets exactly this in their Flutter plugin (`braze-flutter-sdk/ios/braze_plugin.podspec`). CleverTap, who ship dynamic, do not — consistent with the constraint following from static linkage.

### Dependency — resolved

`iOS-PluginBase` and all four `apple-plugin-*` repos released on 3 Sep with their own `static_framework` change, so the pins are now bumped. Both pin sites per plugin are updated — the CocoaPods `s.dependency` and the SPM `exact:` pin in `Package.swift`:

| Pod | Was | Now |
|---|---|---|
| `MoEngagePluginBase` | `7.00.0` | `7.01.0` |
| `MoEngagePluginCards` | `4.00.0` | `4.01.0` |
| `MoEngagePluginGeofence` | `5.00.0` | `5.01.0` |
| `MoEngagePluginInbox` | `5.00.0` | `5.01.0` |
| `MoEngagePluginPersonalize` | `2.0.0` | `2.1.0` |

Verified against the released podspecs: each `x.01.0` / `2.1.0` tag contains `s.static_framework = true`, and the previously pinned `x.00.0` / `2.0.0` versions do **not** — so without this bump the fix would not have reached clients, exactly as flagged above. All five resolve to `MoEngage-iOS-SDK` `11.01.0` (`sdkVerMin` in `iOS-PluginBase@7.01.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOEN-46639]: https://moengagetrial.atlassian.net/browse/MOEN-46639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
