### PR TITLE
MOEN-47181: Flutter CD fault tolerance

### DIFF
--- a/.github/scripts/release.main.kts
+++ b/.github/scripts/release.main.kts
@@ -3,6 +3,8 @@
 @file:Import("../../../sdk-automation-scripts/scripts/common/utils.main.kts")
 @file:Import("./flutter-utils.main.kts")
 
+import kotlin.system.exitProcess
+
 val releasebranch = "master"
 releasePlugins(args[0])
 
@@ -13,21 +15,60 @@ fun releasePlugins(releaseNotes: String) {
     executeCommandOrExitOnFailure("melos bootstrap")
     println("Running Melos get")
     executeCommandOrExitOnFailure("melos get")
-    println("Publish plugins")
-    executeCommandOrExitOnFailure("melos publish --no-dry-run --git-tag-version --yes")
-    println("Merge master branch to development")
 
-    val newTags = executeShellCommandWithStringOutput("git tag --points-at HEAD").trim().split("\n")
-    println("New tags: $newTags")
-    // Post Release
-    mergeMasterToDevBranch()
+    println("Publish plugins")
+    // --no-published skips packages already live on pub.dev, so retries resume from where they left off.
+    val publishExitCode = executeCommandOnShell("melos publish --no-dry-run --git-tag-version --yes --no-published")
+
+    // Tag/release before checking the exit code, so an earlier success isn't dropped if a later package fails.
+    tagAndReleasePublishedPackages(releaseNotes)
+
+    if (publishExitCode != 0) {
+        println("::error::melos publish failed (exit code $publishExitCode). Re-run this workflow to resume with the remaining packages.")
+        exitProcess(publishExitCode)
+    }
+
+    println("Published plugins successfully")
+}
+
+private fun getTagsPointingAtHead(): Set<String> {
+    return executeShellCommandWithStringOutput("git tag --points-at HEAD").trim()
+        .let { if (it.isBlank()) emptySet() else it.split("\n").toSet() }
+}
+
+private fun getLocalTags(): Set<String> {
+    return executeShellCommandWithStringOutput("git tag --list").trim()
+        .let { if (it.isBlank()) emptySet() else it.split("\n").toSet() }
+}
+
+private fun getRemoteTags(): Set<String> {
+    return executeShellCommandWithStringOutput("git ls-remote --tags origin").trim()
+        .let { if (it.isBlank()) emptyList() else it.split("\n") }
+        .mapNotNull { it.substringAfter("refs/tags/", "").removeSuffix("^{}").ifBlank { null } }
+        .toSet()
+}
+
+// Idempotent regardless of where an earlier attempt stopped: candidates are tags not yet
+// pushed to origin (this run's new tags) plus tags still at HEAD (in case a previous
+// attempt pushed the tag but crashed before creating its release). Each candidate only
+// gets a release if it doesn't already have one.
+private fun tagAndReleasePublishedPackages(releaseNotes: String) {
+    val unpushedTags = getLocalTags() - getRemoteTags()
+    val candidateTags = unpushedTags + getTagsPointingAtHead()
+    println("Candidate tags: $candidateTags")
+    if (candidateTags.isEmpty()) return
+
     pushLocalTags()
+
     val releaseTagPackages = packageParentFolder.values.toSet()
-    newTags.forEach { tag ->
-        if (releaseTagPackages.contains(tag.split("-").first())) {
+    candidateTags.forEach { tag ->
+        if (releaseTagPackages.contains(tag.split("-").first()) && !releaseExistsForTag(tag)) {
             println("Creating release for tag: $tag")
             createGitRelease(tag, releaseNotes)
         }
     }
-    println("Published plugins successfully")
+}
+
+private fun releaseExistsForTag(tag: String): Boolean {
+    return executeCommandOnShell("gh release view $tag") == 0
 }

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -1,0 +1,56 @@
+name: Pre Release
+
+# Bumps version/changelog/pubspec.yaml on master and syncs development around it.
+# Safe to re-run: already-bumped packages are skipped, so nothing gets double-bumped.
+on:
+  workflow_call:
+    inputs:
+      releaseTicket:
+        type: string
+        description: 'Release ticket number'
+        required: true
+      isPatchRelease:
+        type: boolean
+        description: 'true for a hotfix cut directly from master - skips the development <-> master merges'
+        required: false
+        default: false
+    secrets:
+      SDK_BOT_ACCESS_TOKEN:
+        required: true
+
+jobs:
+  pre-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sdk automation scripts
+        uses: actions/checkout@v4
+        with:
+          repository: moengage/sdk-automation-scripts
+          path: sdk-automation-scripts
+          token: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
+      - name: Automation script setup
+        uses: ./sdk-automation-scripts/actions/flutter-repository-setup
+      - name: Checkout 🔔
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+          fetch-tags: true
+          path: source
+          token: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
+      - name: Merge Development to Master
+        if: ${{ !inputs.isPatchRelease }}
+        uses: ./sdk-automation-scripts/actions/action-git-development-to-master
+        with:
+          working-directory: source
+      - name: Pre-Release process
+        working-directory: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          kotlin .github/scripts/pre-release.main.kts ${{ inputs.releaseTicket }}
+      - name: Merge Master to Development
+        if: ${{ !inputs.isPatchRelease }}
+        uses: ./sdk-automation-scripts/actions/action-git-master-to-development
+        with:
+          working-directory: source

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,48 +1,29 @@
-name: Release Plugins
+name: Publish
+
+# Publishes plugins - chained from release.yml, or re-run standalone via workflow_dispatch.
+# Retry-safe: --no-published skips already-published packages; tags/releases are created idempotently.
 on:
   workflow_dispatch:
     inputs:
-      releaseTicket:
-        type: string
-        description: 'Enter the Release ticket number'
-        required: true
       releaseNotes:
         type: string
-        description: 'Enter the Release note'
+        description: 'Release notes (only needed when retriggering without a Release run)'
+        required: true
+  workflow_call:
+    inputs:
+      releaseNotes:
+        type: string
+        description: 'Release notes, passed straight through from the Release workflow'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
-  pre-release:
-    runs-on: ubuntu-latest
-    if: contains(fromJSON('["umangmoe", "arshiya-moengage", "kkgowtham-engg-sdk"]'), github.actor)
-    steps:
-      - name: Checkout sdk automation scripts
-        uses: actions/checkout@v4
-        with:
-          repository: moengage/sdk-automation-scripts
-          path: sdk-automation-scripts
-          token: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
-      - name: Automation script setup
-        uses: ./sdk-automation-scripts/actions/flutter-repository-setup
-      - name: Checkout 🔔
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-          path: source
-          token: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
-      - name: Merge Development to Master
-        uses: ./sdk-automation-scripts/actions/action-git-development-to-master
-        with:
-          working-directory: source
-      - name: Pre-Release process
-        working-directory: source
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          kotlin .github/scripts/pre-release.main.kts ${{ github.event.inputs.releaseTicket }}
-  release:
-    needs: pre-release
+  publish:
+    if: >-
+      github.event_name == 'workflow_call' ||
+      contains(fromJSON('["umangmoe", "arshiya-moengage"]'), github.actor)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sdk automation scripts
@@ -56,6 +37,7 @@ jobs:
       - name: Checkout 🔔
         uses: actions/checkout@v4
         with:
+          ref: master
           fetch-depth: 0
           fetch-tags: true
           path: source
@@ -71,15 +53,36 @@ jobs:
         run: gcloud auth activate-service-account --key-file=$HOME/key-file.json
       - name: Create pub.dev Temporary Token
         run: gcloud auth print-identity-token --audiences=https://pub.dev | dart pub token add https://pub.dev
-      - name: Release process
+      - name: Publish plugins
         working-directory: source
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          kotlin .github/scripts/release.main.kts ${{ github.event.inputs.releaseNotes }}
+          kotlin .github/scripts/release.main.kts "${{ inputs.releaseNotes }}"
+
+  notify:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sdk automation scripts
+        uses: actions/checkout@v4
+        with:
+          repository: moengage/sdk-automation-scripts
+          path: sdk-automation-scripts
+          token: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
+      - name: Automation script setup
+        uses: ./sdk-automation-scripts/actions/flutter-repository-setup
+      - name: Checkout 🔔
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+          fetch-tags: true
+          path: source
+          token: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
       - name: Notify release
         working-directory: source
         run: |
-          kotlin .github/scripts/notify-release.main.kts ${{ github.event.inputs.releaseNotes }}
+          kotlin .github/scripts/notify-release.main.kts "${{ inputs.releaseNotes }}"
         env:
           GH_TOKEN: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+# Entry point for a release (isPatchRelease for a hotfix cut from master). Chains
+# pre_release.yml -> publish.yml; each stage can also be re-run independently on failure.
+on:
+  workflow_dispatch:
+    inputs:
+      releaseTicket:
+        type: string
+        description: 'Enter the Release ticket number'
+        required: true
+      releaseNotes:
+        type: string
+        description: 'Enter the Release note'
+        required: true
+      isPatchRelease:
+        type: boolean
+        description: 'Patch/hotfix release - cuts directly from master, skips the development <-> master merges'
+        required: false
+        default: false
+
+jobs:
+  pre-release:
+    if: contains(fromJSON('["umangmoe", "arshiya-moengage"]'), github.actor)
+    uses: ./.github/workflows/pre_release.yml
+    with:
+      releaseTicket: ${{ inputs.releaseTicket }}
+      isPatchRelease: ${{ inputs.isPatchRelease }}
+    secrets: inherit
+
+  publish:
+    needs: pre-release
+    uses: ./.github/workflows/publish.yml
+    with:
+      releaseNotes: ${{ inputs.releaseNotes }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
Splits the single release workflow into 3 independently retriable stages so a failure at any point can be resumed without redoing prior stages, per [MOEN-47181](https://moengagetrial.atlassian.net/browse/MOEN-47181).

- **pre_release.yml** (reusable): version/changelog/pubspec bump on master, plus development <-> master sync merges. Safe to re-run - already-bumped packages are skipped, so nothing double-bumps.
- **publish.yml**: `melos publish --no-published` so a rerun skips packages already live on pub.dev; tags and GitHub releases are created idempotently (checked via `gh release view` before creating), so a rerun never duplicates a tag or release. Chained from `release.yml` via `workflow_call`, and independently retriggerable via `workflow_dispatch` to resume a failed publish without redoing pre-release. `notify` is a separate job so a Slack webhook failure never blocks or re-triggers publish.
- **release.yml**: single entry point chaining pre-release -> publish. `isPatchRelease` toggles a hotfix cut directly from master, skipping the dev<->master merges.
- **release.main.kts**: reworked tag/release logic to be idempotent regardless of where a previous attempt failed.
- Replaces `release-plugins.yml`.

No changelog entry - CI/release-tooling only, no package changes.

## Test plan
- Validated YAML syntax for all 3 workflow files.
- Manually traced the retry-safety flow (double-bump, double-tag, duplicate GitHub release) for pre-release and publish.

[MOEN-47181]: https://moengagetrial.atlassian.net/browse/MOEN-47181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ